### PR TITLE
Support Red Hat x86_64 systems

### DIFF
--- a/manifests/binary.pp
+++ b/manifests/binary.pp
@@ -10,6 +10,9 @@ class helm::binary (
     'i386': {
       $arch = '386'
     }
+    'x86_64': {
+      $arch = 'amd64'
+    }
     default: {
       fail("${::architecture} is not supported")
     }


### PR DESCRIPTION
Previous to this commit, Red Hat x86_64 systems would fail to compile
due to a missing case match. The case in binary.pp would match amd64,
but not x86_64 values.

This commit adds x86_64 to the case statement