### PR TITLE
Fix for upstream Puppet issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.2.5
-    env: PUPPET_GEM_VERSION="~> 5.0" STRICT_VARIABLES="yes"
+    env: PUPPET_GEM_VERSION="~> 5.33" STRICT_VARIABLES="yes"
   - rvm: 2.2.5
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.2.5
-    env: PUPPET_GEM_VERSION="~> 5.33" STRICT_VARIABLES="yes"
+    env: PUPPET_GEM_VERSION="~> 5.3.3" STRICT_VARIABLES="yes"
   - rvm: 2.2.5
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.1.6


### PR DESCRIPTION
Setting the Puppet version to 5.3.3 in the `.travis.yml` file to bypass the issue caused by Puppet 5.3.4