### PR TITLE
Enable to use puppet-archive version 2.1.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/puppetlabs/puppetlabs-helm/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.19.0 < 5.0.0"},
-    {"name":"puppet-archive","version_requirement":">= 2.0.0 < 2.1.0"},
+    {"name":"puppet-archive","version_requirement":">= 2.0.0 <= 2.1.0"},
     {"name":"puppetlabs/translate","version_requirement":">= 0.0.1 < 1.0.0"}
   ],
   "data_provider": null,


### PR DESCRIPTION
Just modify dependency to be able to use puppet-archive version 2.1.0.
I tested locally in a vagrant machine and it works :100: %