### PR TITLE
Allow multiple instances of the same chart

### DIFF
--- a/manifests/chart.pp
+++ b/manifests/chart.pp
@@ -74,7 +74,7 @@ define helm::chart (
       version => $version,
       wait => $wait,
       })
-    $exec = "helm install ${chart}"
+    $exec = "helm install ${release_name}"
     $exec_chart = "helm ${helm_install_flags}"
     $helm_ls_flags = helm_ls_flags({
       ls => true,
@@ -113,7 +113,7 @@ define helm::chart (
       tls_key => $tls_key,
       tls_verify => $tls_verify,
       })
-    $exec = "helm delete ${chart}"
+    $exec = "helm delete ${release_name}"
     $exec_chart = "helm ${helm_delete_flags}"
     $helm_ls_flags = helm_ls_flags({
       ls => true,

--- a/manifests/chart_update.pp
+++ b/manifests/chart_update.pp
@@ -84,7 +84,7 @@ define helm::chart_update (
       version => $version,
       wait => $wait,
       })
-    $exec = "helm upgrade ${chart}"
+    $exec = "helm upgrade ${release_name}"
     $exec_chart = "helm ${helm_chart_update_flags}"
     $unless_chart = false
   }
@@ -109,7 +109,7 @@ define helm::chart_update (
       tls_key => $tls_key,
       tls_verify => $tls_verify,
       })
-    $exec = "helm delete ${chart}"
+    $exec = "helm delete ${release_name}"
     $exec_chart = "helm ${helm_delete_flags}"
     $helm_ls_flags = helm_ls_flags({
       ls => true,

--- a/spec/defines/chart_spec.rb
+++ b/spec/defines/chart_spec.rb
@@ -18,7 +18,7 @@ describe 'helm::chart', :type => :define do
                } }
     it do
       is_expected.to compile.with_all_deps
-      is_expected.to contain_exec('helm install ')
+      is_expected.to contain_exec('helm install foo')
     end
   end
   context 'with ensure => absent' do
@@ -30,7 +30,7 @@ describe 'helm::chart', :type => :define do
                } }
     it do
       is_expected.to compile.with_all_deps
-      is_expected.to contain_exec('helm delete ')
+      is_expected.to contain_exec('helm delete foo')
     end
   end
 end


### PR DESCRIPTION
Ensure the titles of Exec['helm install ...'] resources are unique by
referring to $release_name rather than $chart.