### PR TITLE
release prep for 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 1.10
+Fixes bugs:
+- #54 adds missing parameter to init.pp
+- Fixes incorrect type for node selectory
+
+Adds in PDK compliance
+
 # Version 1.0.1
 Updates environment variable for use with upstream kubernetes module 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-helm",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "puppetlabs",
   "summary": "A module to install Helm, a kubernetes package manager",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR is for updating the changelog and metadata.json as part of the release prep for the 1.1.0 release.