### PR TITLE
allow helm download to be configurable

### DIFF
--- a/manifests/binary.pp
+++ b/manifests/binary.pp
@@ -1,7 +1,8 @@
 # == Class: helm::binary
 class helm::binary (
-  String $version      = $helm::version,
-  String $install_path = $helm::install_path,
+  String $version         = $helm::version,
+  String $install_path    = $helm::install_path,
+  String $archive_baseurl = $helm::archive_baseurl,
 ){
 
   case $::architecture {
@@ -23,7 +24,7 @@ class helm::binary (
 
   archive { 'helm':
     path            => "/tmp/${archive}",
-    source          => "https://kubernetes-helm.storage.googleapis.com/${archive}",
+    source          => "${archive_baseurl}/${archive}",
     extract_command => "tar xfz %s linux-${arch}/helm --strip-components=1 -O > ${install_path}/helm-${version}",
     extract         => true,
     extract_path    => $install_path,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,7 +116,11 @@
 # The version of helm to install.
 # Defaults to 2.5.1
 #
-
+# [*archive_baseurl*]
+# The base URL for downloading the helm archive, must contain file helm-v${version}-linux-${arch}.tar.gz
+# Defaults to https://kubernetes-helm.storage.googleapis.com
+# URLs supported by puppet/archive module will work, e.g. puppet:///modules/helm_files
+#
 class helm (
   Boolean $canary_image                     = $helm::params::canary_image,
   Boolean $client_only                      = $helm::params::client_only,
@@ -144,6 +148,7 @@ class helm (
   Optional[String]  $tls_ca_cert            = $helm::params::tls_ca_cert,
   Boolean $upgrade                          = $helm::params::upgrade,
   String $version                           = $helm::params::version,
+  String $archive_baseurl                   = $helm::params::archive_baseurl,
 ) inherits helm::params {
 
   if $::kernel {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,4 +27,5 @@ class helm::params {
   $tls_ca_cert          = undef
   $upgrade              = false
   $version              = '2.7.2'
+  $archive_baseurl      = 'https://kubernetes-helm.storage.googleapis.com'
 }

--- a/spec/classes/binary_spec.rb
+++ b/spec/classes/binary_spec.rb
@@ -8,6 +8,7 @@ describe 'helm::binary', :type => :class do
     let(:params) { {
                     'install_path' => '/usr/bin',
                     'version' => '2.5.1',
+                    'archive_baseurl' => 'https://kubernetes-helm.storage.googleapis.com',
                  } }
     it do
       is_expected.to compile


### PR DESCRIPTION
In order to run this where access to internet is blocked or where storage.googleapis.com is blocked, I would like to make base URL for the helm download configurable. 