### PR TITLE
Fix chart update

### DIFF
--- a/manifests/chart_update.pp
+++ b/manifests/chart_update.pp
@@ -86,7 +86,7 @@ define helm::chart_update (
       })
     $exec = "helm upgrade ${name}"
     $exec_chart = "helm ${helm_chart_update_flags}"
-    $unless_chart = false
+    $unless_chart = undef
   }
 
   if $ensure == absent {

--- a/manifests/chart_update.pp
+++ b/manifests/chart_update.pp
@@ -21,7 +21,7 @@ define helm::chart_update (
   Boolean $install                = true,
   Optional[String] $kube_context  = undef,
   Optional[String] $namespace     = undef,
-  Optional[String] $no_hooks      = false,
+  Boolean $no_hooks               = false,
   Array $path                     = undef,
   Boolean $purge                  = true,
   Optional[String] $repo          = undef,
@@ -39,7 +39,7 @@ define helm::chart_update (
   Boolean $tls_verify             = false,
   Optional[Array] $values         = [],
   Boolean $verify                 = false,
-  String $version                 = undef,
+  Optional[String] $version       = undef,
   Boolean $wait                   = false,
 ){
 
@@ -84,7 +84,7 @@ define helm::chart_update (
       version => $version,
       wait => $wait,
       })
-    $exec = "helm upgrade ${chart}"
+    $exec = "helm upgrade ${name}"
     $exec_chart = "helm ${helm_chart_update_flags}"
     $unless_chart = false
   }
@@ -109,7 +109,7 @@ define helm::chart_update (
       tls_key => $tls_key,
       tls_verify => $tls_verify,
       })
-    $exec = "helm delete ${chart}"
+    $exec = "helm delete ${name}"
     $exec_chart = "helm ${helm_delete_flags}"
     $helm_ls_flags = helm_ls_flags({
       ls => true,


### PR DESCRIPTION
These are fixes that were made in chart.pp but didn't get made in chart_update.pp. I think it would be difficult to get this to work as is. 

Setting unless attribute to false on the exec (so it runs every time) doesn't work in puppet 4.10.6. 