### PR TITLE
Add policy apigroup to tiller role permissions

### DIFF
--- a/templates/tiller-role.yaml.epp
+++ b/templates/tiller-role.yaml.epp
@@ -9,7 +9,7 @@ metadata:
   name: tiller-manager
   namespace: <%= $namespace %>
 rules:
-- apiGroups: ["", "extensions", "apps", "networking.k8s.io", "batch"]
+- apiGroups: ["", "extensions", "apps", "networking.k8s.io", "batch", "policy"]
   resources: ["*"]
   verbs: ["*"]
 ---


### PR DESCRIPTION
This will allow Tiller to manage namespaced policy objects such as
poddisruptionbudgets