### PR TITLE
IAC-1238 - remove redhat support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,12 +23,6 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7"

--- a/provision.yaml
+++ b/provision.yaml
@@ -13,4 +13,4 @@
     images: ['ubuntu/xenial64', 'debian/stretch64', 'centos/7']
   release_checks:
     provisioner: abs
-    images: ['redhat-7-x86_64', 'redhat-8-x86_64', 'centos-7-x86_64', 'ubuntu-1604-x86_64']
+    images: ['centos-7-x86_64', 'ubuntu-1604-x86_64']


### PR DESCRIPTION
Remove redhat support because docker doesn't support anymore redhat and this leaves the machines in a broken state 
See: https://github.com/docker/docker-install/issues/190