### PR TITLE
Replace retry in order to avoid GhA permissions error

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -149,6 +149,7 @@ jobs:
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake helm::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run helm::puppetserver_setup -i ./inventory.yaml
     - name: Install agent
+      run: |
         command: buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
 
     - name: Install module

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -126,7 +126,7 @@ jobs:
         echo ::endgroup::
     - name: Disable gpg check google-cloud.repo
       run: |
-          if eval "bundle exec bolt --modulepath spec/fixtures/modules command run \"sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo\" --targets '*' -i ./inventory.yaml"; then
+          if eval "bundle exec bolt --modulepath spec/fixtures/modules command run \"sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo\" --targets '*' -i ./spec/fixtures/litmus_inventory.yaml"; then
             rc=0
           else
             rc=1
@@ -134,7 +134,7 @@ jobs:
           if test $rc -ne 0; then
             attempt_number=0
             while test $attempt_number -lt 0; do
-              if eval "bundle exec bolt --modulepath spec/fixtures/modules command run \"sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo\" --targets '*' -i ./inventory.yaml"; then
+              if eval "bundle exec bolt --modulepath spec/fixtures/modules command run \"sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo\" --targets '*' -i spec/fixtures/litmus_veventory.yaml"; then
                 rc=0
                 break
               else
@@ -147,10 +147,10 @@ jobs:
       
     - name: Puppetserver Setup
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake helm::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run helm::puppetserver_setup -i ./inventory.yaml
+        buildevents cmd $TRACE_ID $STEP_ID 'rake helm::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run helm::puppetserver_setup collection='${{ matrix.collection }}' -i spec/fixtures/litmus_inventory.yaml
     - name: Install agent
       run: |
-        command: buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+       buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
 
     - name: Install module
       run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -125,12 +125,26 @@ jobs:
         sed -e 's/password: .*/password: "[redacted]"/' < inventory.yaml || true
         echo ::endgroup::
     - name: Disable gpg check google-cloud.repo
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 30
-        max_attempts: 5
-        retry_wait_seconds: 60
-        command: buildevents cmd $TRACE_ID $STEP_ID 'rake helm::disable_gpg' -- bundle exec bolt --modulepath spec/fixtures/modules command run "sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo" --targets '*' -i ./inventory.yaml
+      run: |
+          if eval "bundle exec bolt --modulepath spec/fixtures/modules command run \"sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo\" --targets '*' -i ./inventory.yaml"; then
+            rc=0
+          else
+            rc=1
+          fi
+          if test $rc -ne 0; then
+            attempt_number=0
+            while test $attempt_number -lt 0; do
+              if eval "bundle exec bolt --modulepath spec/fixtures/modules command run \"sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo\" --targets '*' -i ./inventory.yaml"; then
+                rc=0
+                break
+              else
+                rc=1
+                sleep 2s
+                ((attempt_number=attempt_number+1))
+              fi
+            done
+          fi
+      
     - name: Puppetserver Setup
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake helm::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run helm::puppetserver_setup -i ./inventory.yaml

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -139,7 +139,7 @@ jobs:
                 break
               else
                 rc=1
-                sleep 2s
+                sleep 2s 
                 ((attempt_number=attempt_number+1))
               fi
             done
@@ -149,11 +149,6 @@ jobs:
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake helm::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run helm::puppetserver_setup -i ./inventory.yaml
     - name: Install agent
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 30
-        max_attempts: 5
-        retry_wait_seconds: 60
         command: buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
 
     - name: Install module

--- a/plans/puppetserver_setup.pp
+++ b/plans/puppetserver_setup.pp
@@ -1,9 +1,11 @@
 plan helm::puppetserver_setup(
+  Optional[String] $collection = 'puppet7'
 ) {
   $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'controller' }
-  $puppet_server_string = $puppet_server[0].name
+  $puppet_server_facts = facts($puppet_server[0])
+  $platform = $puppet_server_facts['platform']
   # install pe server
-  run_task('provision::install_puppetserver', $puppet_server)
+  run_task('provision::install_puppetserver', $puppet_server, { 'collection' => $collection, 'platform' => $platform })
 }
 
 


### PR DESCRIPTION
Integration Testing : .github#L1
nick-invision/retry@v1 is not allowed to be used in puppetlabs/puppetlabs-helm. Actions in this workflow must be: within a repository owned by puppetlabs, created by GitHub, verified in the GitHub Marketplace or match the following: 