### PR TITLE
(MAINT) Fix failing acceptance tests

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -352,7 +352,7 @@ Default value: `$helm::params::version`
 Data type: `String`
 
 The base URL for downloading the helm archive, must contain file helm-v${version}-linux-${arch}.tar.gz
-Defaults to https://kubernetes-helm.storage.googleapis.com
+Defaults to https://get.helm.sh
 URLs supported by puppet/archive module will work, e.g. puppet:///modules/helm_files
 
 Default value: `$helm::params::archive_baseurl`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,7 +120,7 @@
 #
 # @param archive_baseurl
 #   The base URL for downloading the helm archive, must contain file helm-v${version}-linux-${arch}.tar.gz
-#   Defaults to https://kubernetes-helm.storage.googleapis.com
+#   Defaults to https://get.helm.sh
 #   URLs supported by puppet/archive module will work, e.g. puppet:///modules/helm_files
 #
 class helm (

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,5 +31,5 @@ class helm::params {
   $tls_ca_cert               = undef
   $upgrade                   = false
   $version                   = '2.7.2'
-  $archive_baseurl           = 'https://kubernetes-helm.storage.googleapis.com'
+  $archive_baseurl           = 'https://get.helm.sh'
 }

--- a/spec/classes/binary_spec.rb
+++ b/spec/classes/binary_spec.rb
@@ -9,13 +9,13 @@ describe 'helm::binary', :type => :class do
                     'install_path'    => '/usr/bin',
                     'version'         => '2.5.1',
                     'proxy'           => 'https://proxy',
-                    'archive_baseurl' => 'https://kubernetes-helm.storage.googleapis.com',
+                    'archive_baseurl' => 'https://get.helm.sh',
                  } }
     it do
       is_expected.to compile
       is_expected.to contain_archive('helm').with({
         'path' => '/tmp/helm-v2.5.1-linux-amd64.tar.gz',
-        'source' => 'https://kubernetes-helm.storage.googleapis.com/helm-v2.5.1-linux-amd64.tar.gz',
+        'source' => 'https://get.helm.sh/helm-v2.5.1-linux-amd64.tar.gz',
         'extract_command' => 'tar xfz %s linux-amd64/helm --strip-components=1 -O > /usr/bin/helm-2.5.1',
         'extract' => 'true',
         'extract_path' => '/usr/bin',


### PR DESCRIPTION
## Context

Prior to this PR the acceptance tests were failing because this module defaulted to a deprecated archive url for helm binaries.

## What has changed

This PR updates the default to `https://get.helm.sh`. The archive path has not changed.