### PR TITLE
pdksync - (GH-iac-335) Remove Support for Ubuntu 16.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+
       ]
     }
   ],


### PR DESCRIPTION
(GH-iac-335) Remove Support for Ubuntu 16.04
pdk version: `2.1.0` 
